### PR TITLE
Property "zoomContainer" throws an error on "JSON.stringify" because …

### DIFF
--- a/src/react-image-zoom.js
+++ b/src/react-image-zoom.js
@@ -26,7 +26,7 @@ class ReactImageZoom extends React.Component {
   }
 
   rerenderImageZoom(props) {
-    this.imageZoom = new ImageZoom(this.container, JSON.parse(JSON.stringify(props)));
+    this.imageZoom = new ImageZoom(this.container, {...this.props});
   }
 
   setup() {


### PR DESCRIPTION
…it contains type "node"